### PR TITLE
allow chrono constants to be used on device (with cuda 10.{0-1} compilers)

### DIFF
--- a/include/__config
+++ b/include/__config
@@ -810,11 +810,15 @@ typedef unsigned int   char32_t;
 #  define _LIBCPP_CONSTEXPR constexpr
 #endif
 
+#ifdef __CUDA_ARCH__
+#  define _LIBCPP_INLINE_CONSTEXPR __device__ const
+#else
 #if _LIBCPP_STD_VER > 17
 #  define _LIBCPP_INLINE_CONSTEXPR inline constexpr
 #else
 #  define _LIBCPP_INLINE_CONSTEXPR static constexpr
 #endif
+#endif  // __CUDA_ARCH__
 
 #ifdef _LIBCPP_CXX03_LANG
 #  define _LIBCPP_DEFAULT {}

--- a/include/chrono
+++ b/include/chrono
@@ -1675,7 +1675,7 @@ using local_days    = local_time<days>;
 
 #endif // _LIBCPP_HAS_CLOCK_API_EXTERNAL
 
-struct last_spec { explicit last_spec() = default; };
+struct last_spec { last_spec() = default; };
 
 class day {
 private:


### PR DESCRIPTION
- constexpr functions may be used on device when compiling with `--expt-relaxed-constexpr.` some of these functions end up using types that are also annotated with constexpr, yet can't be used on device with nvcc 10.0 and 10.1 compilers. the weekday and the month constexpr definitions are the types that are referenced in some of the fundamental functions in the std chrono library
- whilst the weekday and month types may be used in 10.2, using them inside a kernel produces a device sync. (runtime) failure
- this pr annotates those symbols explicitly with `__device__ const` to quiesce the compiler
- this will let us write more standard conforming code without crafting ugly workarounds or copying `std::chrono` code to workaround compiler issues

@trxcllnt please review.